### PR TITLE
0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /out/
 /.gradle/
 /.idea/
+/META-INF/
 /config.json
 /menmu.log

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Main-Class: com.menmasystems.menmudiscordbot.Menmu
-

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
 
 dependencies {
     implementation files('libs/Discord4J.jar')
-    implementation 'com.sedmelluq:lavaplayer:1.3.52'
+    implementation 'com.sedmelluq:lavaplayer:1.3.53'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'ch.qos.logback:logback-classic:1.2.3'
     implementation 'com.google.api-client:google-api-client:1.23.0'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.menmasystems'
-version '0.1.1'
+version '0.1.2'
 
 allprojects {
     repositories {
@@ -14,7 +14,7 @@ allprojects {
 
 dependencies {
     implementation files('libs/Discord4J.jar')
-    implementation 'com.github.menmaa:lavaplayer:master-SNAPSHOT'
+    implementation 'com.sedmelluq:lavaplayer:1.3.52'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'ch.qos.logback:logback-classic:1.2.3'
     implementation 'com.google.api-client:google-api-client:1.23.0'

--- a/src/main/java/com/menmasystems/menmudiscordbot/Menmu.java
+++ b/src/main/java/com/menmasystems/menmudiscordbot/Menmu.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ScheduledFuture;
 
 public class Menmu {
 
-    public static final String VERSION_NUMBER = "0.1.1 (Beta)";
+    public static final String VERSION_NUMBER = "0.1.2 (Beta)";
     public static final String INVITE_URL = "https://menmasystems.com/menmu/invite";
     public static final String RES_URL = "https://menmasystems.com/menmu/resources/";
     public static final Color DEFAULT_EMBED_COLOR = Color.of(0x47FFFF);

--- a/src/main/java/com/menmasystems/menmudiscordbot/MenmuTrackScheduler.java
+++ b/src/main/java/com/menmasystems/menmudiscordbot/MenmuTrackScheduler.java
@@ -9,6 +9,7 @@ import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.tools.Units;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackState;
 import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.channel.TextChannel;
 import discord4j.rest.util.Color;
@@ -51,8 +52,6 @@ public class MenmuTrackScheduler extends AudioEventAdapter {
             AudioTrack next = queue.poll();
             GuildData guildData = Menmu.getGuildData(guild.getId());
             if(next == null && guildData.getQueueOnRepeat() != null) {
-                Menmu.sendSuccessMessage(guildData.getBoundTextChannel(), ":information_source: Repeating queue...");
-
                 List<AudioTrack> repeatingQueue = Menmu.getGuildData(guild.getId()).getQueueOnRepeat();
                 for(AudioTrack track : repeatingQueue) {
                     queue.offer(track.makeClone());
@@ -209,6 +208,7 @@ public class MenmuTrackScheduler extends AudioEventAdapter {
         AudioTrack removed = audioTracks.remove(position - 1);
         queue.clear();
         for(AudioTrack track : audioTracks) {
+            if(track.getState() != AudioTrackState.INACTIVE) continue;
             queue.offer(track);
         }
         if(guildData.getQueueOnRepeat() != null) {

--- a/src/main/java/com/menmasystems/menmudiscordbot/MenmuTrackScheduler.java
+++ b/src/main/java/com/menmasystems/menmudiscordbot/MenmuTrackScheduler.java
@@ -14,8 +14,6 @@ import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.channel.TextChannel;
 import discord4j.rest.util.Color;
 import discord4j.rest.util.Image;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 import java.util.LinkedList;
@@ -33,9 +31,6 @@ import java.util.concurrent.TimeUnit;
  */
 
 public class MenmuTrackScheduler extends AudioEventAdapter {
-
-    public static final int MAX_TRACK_START_RETRIES = 5;
-    private static final Logger logger = LoggerFactory.getLogger(MenmuTrackScheduler.class);
 
     private Guild guild;
     private final AudioPlayer audioPlayer;

--- a/src/main/java/com/menmasystems/menmudiscordbot/commandhandlers/PlayCommandHandler.java
+++ b/src/main/java/com/menmasystems/menmudiscordbot/commandhandlers/PlayCommandHandler.java
@@ -16,8 +16,6 @@ import discord4j.core.event.domain.message.MessageCreateEvent;
 import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.User;
 import discord4j.core.object.entity.channel.MessageChannel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
@@ -32,8 +30,6 @@ import java.util.List;
  */
 
 public class PlayCommandHandler implements CommandHandler {
-
-    private static final Logger logger = LoggerFactory.getLogger(PlayCommandHandler.class);
 
     @Override
     public Mono<Void> handle(MessageCreateEvent event, MessageChannel channel, List<String> params) {

--- a/src/main/java/com/menmasystems/menmudiscordbot/eventhandlers/MessageCreateEventHandler.java
+++ b/src/main/java/com/menmasystems/menmudiscordbot/eventhandlers/MessageCreateEventHandler.java
@@ -32,7 +32,7 @@ public class MessageCreateEventHandler implements Consumer<MessageCreateEvent> {
                 .filter(cmdPrefix -> msg.startsWith(cmdPrefix + "!"))
                 .map(cmdPrefix -> Arrays.asList(msg.substring(cmdPrefix.length() + 1).split(" ")))
                 .flatMap(params -> messageCreateEvent.getMessage().getChannel()
-                        .flatMap(channel -> Menmu.getCommandHandler(params.get(0))
+                        .flatMap(channel -> Menmu.getCommandHandler(params.get(0).toLowerCase())
                                 .doOnError(UnknownCommandException.class, unused -> {
                                     String message = ":no_entry_sign: I'm sorry, I don't seem to be able to recognize this command.";
                                     Menmu.sendErrorMessage(channel, message, null);

--- a/src/main/java/com/menmasystems/menmudiscordbot/eventhandlers/ReactionAddEventHandler.java
+++ b/src/main/java/com/menmasystems/menmudiscordbot/eventhandlers/ReactionAddEventHandler.java
@@ -107,7 +107,7 @@ public class ReactionAddEventHandler implements Consumer<ReactionAddEvent> {
                     }
                     spec.setDescription(sb.toString());
 
-                    int trackListSize = trackList.size();// - ((np != null) ? 1 : 0);
+                    int trackListSize = trackList.size() - ((np != null) ? 1 : 0);
                     long totalLength = 0;
                     for(AudioTrack track : trackList) {
                         long length = track.getInfo().length;

--- a/src/main/java/com/menmasystems/menmudiscordbot/eventhandlers/ReadyEventHandler.java
+++ b/src/main/java/com/menmasystems/menmudiscordbot/eventhandlers/ReadyEventHandler.java
@@ -28,9 +28,6 @@ public class ReadyEventHandler implements Consumer<ReadyEvent> {
         if(Menmu.presenceTask == null) {
             Menmu.presenceTask = Menmu.getGpScheduledExecutor().scheduleAtFixedRate(() -> {
                 try {
-                    //Long guilds = readyEvent.getClient().getGuilds().count().block();
-                    //if(guilds == null) guilds = 0L;
-
                     String activityMsg = "v" + Menmu.VERSION_NUMBER + " | m!help";
                     readyEvent.getClient().updatePresence(Presence.online(Activity.playing(activityMsg))).block();
                     Menmu.menma = readyEvent.getClient().getUserById(Snowflake.of(303676987975663616L)).block();


### PR DESCRIPTION
Update to v0.1.2

Changelog:
* Update to lavaplayer 1.3.53 - Implements various fixes. [Changelog](https://github.com/sedmelluq/lavaplayer/blob/master/CHANGELOG.md)
* Fixed a bug where if remove command was used while queue repeat is enabled next track would throw an exception.
* Fixed a bug where after changing pages on a queue message the track counter was inaccurate.
* No more 'Repeating Queue...' message spamming when queue repeats.
* All commands are now case insensitive.
* Code cleanup.